### PR TITLE
Added ProtoBuf in Networking category

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ and Android apps
 * [OkHttp](https://github.com/square/okhttp) - An HTTP+HTTP/2 client for Android and Java applications
 * [Retrofit](https://square.github.io/retrofit) - Retrofit turns your REST API into a Java interface
 * [Volley](https://github.com/google/volley) - Volley is an HTTP library that makes networking for Android apps easier and most importantly, faster
+* [ProtoBuf - A faster serialization library by Google](https://www.youtube.com/watch?v=IwxIIUypnTE) - Developed by Google, ProtoBuff is serialization library which is way faster than Serializable, Parcelable, JSON.
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ and Android apps
 * [Fast Android Networking](https://github.com/amitshekhariitbhu/Fast-Android-Networking) - A Complete Fast Android Networking Library that also supports HTTP/2
 * [Ion](https://github.com/koush/ion) - Android Asynchronous Networking and Image Loading
 * [OkHttp](https://github.com/square/okhttp) - An HTTP+HTTP/2 client for Android and Java applications
+* [ProtoBuf - A faster serialization library by Google](https://www.youtube.com/watch?v=IwxIIUypnTE) - Developed by Google, ProtoBuff is serialization library which is way faster than Serializable, Parcelable, JSON.
 * [Retrofit](https://square.github.io/retrofit) - Retrofit turns your REST API into a Java interface
 * [Volley](https://github.com/google/volley) - Volley is an HTTP library that makes networking for Android apps easier and most importantly, faster
-* [ProtoBuf - A faster serialization library by Google](https://www.youtube.com/watch?v=IwxIIUypnTE) - Developed by Google, ProtoBuff is serialization library which is way faster than Serializable, Parcelable, JSON.
 
 ### Persistence
 


### PR DESCRIPTION
ProtoBuf is a serialization library developed by Google to perform serialization-deserialization. It is language independent library, takes less memory and performs faster conversions. A smaller library, protobuf lite is made for Android which has even less memory footprint (link -[Github Page](https://github.com/google/protobuf), [Protocol Buffer](https://developers.google.com/protocol-buffers/) )