### PR TITLE
Adding Functional Programming Flow API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ If you feel that a particular resource(s) listed here is not a good fit for this
     * [Crash Reporting & Tracking](#crash-reporting--tracking)
     * [Debugging](#debugging)
     * [Dependency Injection](#dependency-injection)
-    * [Functional Programming](#functional-programming)
     * [Image Loading](#image-loading)
     * [Image Processing](#image-processing)
     * [Logging](#logging)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you feel that a particular resource(s) listed here is not a good fit for this
     * [Crash Reporting & Tracking](#crash-reporting--tracking)
     * [Debugging](#debugging)
     * [Dependency Injection](#dependency-injection)
+    * [Functional Programming](#functional-programming)
     * [Image Loading](#image-loading)
     * [Image Processing](#image-processing)
     * [Logging](#logging)
@@ -132,6 +133,10 @@ and Android apps
 * [Dagger](https://github.com/square/Dagger) - A fast dependency injector for Android and Java
 * [Dagger 2](https://github.com/google/dagger) - A fast dependency injector for Android and Java
 * [Dart](https://github.com/f2prateek/dart) - Extras "injection" library for Android
+
+### Functional Programming
+* [Flow](https://github.com/00ec454/Flow) - Java8 Stream like API for android
+
 
 ### Image Loading
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,6 @@ and Android apps
 * [Dagger 2](https://github.com/google/dagger) - A fast dependency injector for Android and Java
 * [Dart](https://github.com/f2prateek/dart) - Extras "injection" library for Android
 
-### Functional Programming
-* [Flow](https://github.com/00ec454/Flow) - Java8 Stream like API for android
-
-
 ### Image Loading
 
 * [Android Universal Image Loader](https://github.com/nostra13/Android-Universal-Image-Loader) - Powerful and flexible library for loading, caching and displaying images on Android
@@ -267,6 +263,7 @@ and Android apps
 
 ### Utilities (Advanced)
 
+* [Flow](https://github.com/00ec454/Flow) - Java8 Stream like API for android
 * [EventBus](https://github.com/greenrobot/EventBus) - Android optimized event bus that simplifies communication between Activities, Fragments, Threads, Services, etc. Less code, better quality
 * [JavaPoet](https://github.com/square/javapoet) - A Java API for generating .java source files.
 * [Lightweight Stream API](https://github.com/aNNiMON/Lightweight-Stream-API) - Stream API from Java 8 rewritten on iterators for Java 7 and below


### PR DESCRIPTION
Android API less than 25 can not use java8 and stream API. This little Flow library will allow developer to use the Stream like functionalties.